### PR TITLE
do not add trailing dot if the object is empty

### DIFF
--- a/flatten.js
+++ b/flatten.js
@@ -37,7 +37,7 @@ function flatten(obj) {
       }
       keys = Object.keys(value)
       len = keys.length
-      if (prefix) prefix = prefix + "."
+      if (prefix && len.length > 0) prefix = prefix + "."
       if (len == 0) _route(prefix, null)
       for (i = 0; i < len; i++) {
         _route(prefix + keys[i], value[keys[i]])


### PR DESCRIPTION
I had a scenario like this : 
```
{
    a: {
           b : {}
    }
}
```
In this case, we're getting the path as `"a.b."`, so an extra trailing dot if the value of a key is an empty object. I'm removing that extra trailing dot in this PR.
Thanks!